### PR TITLE
Update typography

### DIFF
--- a/src/extension.js
+++ b/src/extension.js
@@ -46,7 +46,7 @@ var BatLabelIndicator = GObject.registerClass(
   class BatLabelIndicator extends St.Label {
     _init(settings) {
       super._init({
-        text: _('Calculating...'),
+        text: _('Calculating…'),
         y_align: Clutter.ActorAlign.CENTER
       });
       this._settings = settings;
@@ -81,7 +81,7 @@ var BatLabelIndicator = GObject.registerClass(
       }
 
       return status.includes('Charging') ? _(" +%s W").format(this._meas()) :
-              status.includes('Discharging') ? _(" -%s W").format(this._meas()) :
+              status.includes('Discharging') ? _(" −%s W").format(this._meas()) :
               status.includes('Unknown') ? _(" ?") :
                _(" N/A");
     }


### PR DESCRIPTION
- [x] I replaced n-dash (-) with a proper minus (−). The difference is important because n-dash was placed on middle level of letters and minus on middle level of numbers. As the result minus looks much better near the digits.
- [x] I also replaced tree dots (...) to a proper ellipsis symbol. Ellipsis is shorter and looks better.