### PR TITLE
Add support for sbs-battery

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -13,6 +13,7 @@ import Clutter from 'gi://Clutter';
 const BAT0 = '/sys/class/power_supply/BAT0/';
 const BAT1 = '/sys/class/power_supply/BAT1/';
 const BAT2 = '/sys/class/power_supply/BAT2/';
+const SBS0 = '/sys/class/power_supply/sbs-5-000b/';
 
 let retry_count = 0;
 const max_retries = 5;
@@ -46,7 +47,7 @@ function getBatteryIndicator(callback) {
 // Function to get the appropriate battery path and its type
 function getBatteryPath(battery) {
     // Array of possible battery paths
-    const batteryPaths = [BAT0, BAT1, BAT2];
+    const batteryPaths = [BAT0, BAT1, BAT2, SBS0];
     const invalidPath = -1;
 
     if (battery === 0) {
@@ -161,7 +162,7 @@ let BatLabelIndicator = GObject.registerClass(
  _meas() {
     const power = this._getPower();
     const padSingleDigit = this._settings.get_boolean('pad-single-digit');
-    const powerValue = power < 0 ? 0 : Math.round(power);
+    const powerValue = Math.round(power < 0 ? -power : power);
     return padSingleDigit ? String(powerValue).padStart(2, '0') : String(powerValue);
 }
 

--- a/prefs.js
+++ b/prefs.js
@@ -48,7 +48,7 @@ export default class MyExtensionPreferences extends ExtensionPreferences {
 
         // Create a StringList and populate it with battery options
         const batteryStringList = new Gtk.StringList();
-        batteryStringList.splice(0, 0, ['Automatic', 'BAT0', 'BAT1', 'BAT2']);
+        batteryStringList.splice(0, 0, ['Automatic', 'BAT0', 'BAT1', 'BAT2', 'SBS0']);
 
         // Create a ComboRow for the 'battery' setting
         const batteryRow = new Adw.ComboRow({


### PR DESCRIPTION
Note: I don't actually know javascript. I'm an embedded guy.

These batteries appear in ARM systems.
My FydeTab Duo has one and I really wanted this extension to work with it.

From device tree `rk3588s-tablet-12c.dtsi`:
```dts
&i2c5 {
	status = "okay";
	pinctrl-names = "default";
	pinctrl-0 = <&i2c5m3_xfer>;
    battery: sbs-battery@b {
			status = "okay";
            compatible = "sbs,sbs-battery";
            reg = <0x0b>;
            sbs,poll-retry-count = <100>;
            sbs,i2c-retry-count = <100>;
    };
};
```

The sysfs listing looks like this:
```
[bill88t@duo | ~]> ls /sys/class/power_supply/sbs-5-000b
capacity                     current_avg         hwmon8             serial_number      type
capacity_error_margin        current_now         manufacture_day    status             uevent
capacity_level               cycle_count         manufacture_month  subsystem          voltage_max_design
charge_full                  device              manufacturer       technology         voltage_min_design
charge_full_design           energy_full         manufacture_year   temp               voltage_now
charge_now                   energy_full_design  model_name         time_to_empty_avg  wakeup3
constant_charge_current_max  energy_now          power              time_to_empty_now
constant_charge_voltage_max  health              present            time_to_full_avg
```

The power appeared always zero since the reported current draw is negative.
Fixed the logic so it's not capped and instead inverted.

Please let me know if any further clarifications or info is needed.