### PR TITLE
Feature: Sum up battery readings

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -5,5 +5,5 @@
     "shell-version": ["45", "46", "47"],
     "url": "https://github.com/halfmexican/battery-usage-wattmeter-extension",
     "uuid": "battery-usage-wattmeter@halfmexicanhalfamazing.gmail.com",
-    "version": 15
+    "version": 19
 }

--- a/prefs.js
+++ b/prefs.js
@@ -63,6 +63,19 @@ export default class MyExtensionPreferences extends ExtensionPreferences {
             Gio.SettingsBindFlags.DEFAULT
         );
 
+        // Add new SwitchRow for 'combine-batteries'
+        const combineBatteriesRow = new Adw.SwitchRow({
+            title: _('Combine Battery Readings'),
+            subtitle: _('Sum the power readings from all batteries'),
+        });
+        behaviorGroup.add(combineBatteriesRow);
+        window._settings.bind(
+            'combine-batteries',
+            combineBatteriesRow,
+            'active',
+            Gio.SettingsBindFlags.DEFAULT
+        );
+
         const hideNARow = new Adw.SwitchRow({
             title: _('Hide N/A Status'),
             subtitle: _(

--- a/schemas/org.gnome.shell.extensions.battery_usage_wattmeter.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.battery_usage_wattmeter.gschema.xml
@@ -13,6 +13,11 @@
       <summary></summary>
       <description></description>
   </key>
+  <key type="b" name="combine-batteries">
+    <default>false</default>
+    <summary>Combine Battery Readings</summary>
+    <description>If true, sum the power readings from all available batteries.</description>
+  </key>
   <key name="hide-na" type="b">
     <default>true</default>
     <summary>Hide N/A status</summary>


### PR DESCRIPTION
for Devices that use multiple batteries at the same time (for example Surface book).

I am unsure about the appropriate version number bump.
The extension I installed via gnome-extension-manager tells me the current ver is 18 so I chose 19..

not much to say, hope this improvement will be accepted :)